### PR TITLE
refactor: command_queue

### DIFF
--- a/front_end_tests/unit_tests/test_command_prompt.py
+++ b/front_end_tests/unit_tests/test_command_prompt.py
@@ -1,4 +1,3 @@
-import sys
 import pytest
 import string
 import random
@@ -12,8 +11,8 @@ from PyQt6.QtWidgets import QApplication, QLabel, QPushButton, QComboBox
 
 # Widgets, functions and variables to test
 from ground_station.frontend.command_prompt import CommandPrompt
-from ground_station.frontend.utils import add_to_queue, get_from_queue, valid_commands, queue
-from ground_station.frontend import utils
+from ground_station.frontend.utils import valid_commands
+from ground_station.backend import command_queue
 
 DEFAULT_MAX_NO_OF_COMMANDS = 7 # Default upper-limit for no. of commands used in testing
 
@@ -58,23 +57,13 @@ def widget(qapp: QApplication,
 @pytest.fixture
 def reset_queue():
     """
-    Removes all command codes from `queue` in `utils.py`.
+    Removes all command codes from `queue` in `backend/command_queue.py`,
+    and resets the transfer_acknowledgment flag to False.
     """
     
-    while not queue.empty():
-            queue.get()
-
-def update_transfer_acknowledgement():
-    utils.transfer_acknowledgment = False
-
-@pytest.fixture
-def reset_transfer_acknowledgement():
-    """
-    Resets `transfer_acknowledgment` to `False`.
-    """
-    update_transfer_acknowledgement()
-
-    
+    while not command_queue.command_queue.empty():
+        command_queue.command_queue.get()
+    command_queue.transfer_acknowledgment = False
 
 
 def generate_invalid_commands(n: int) -> list[str]:
@@ -132,16 +121,13 @@ class TestCommandPrompt:
     def test_drop_down_and_submit_button_functionality(self,
                                                        qapp: QApplication,
                                                        qtbot: QtBot,
-                                                       reset_queue,
-                                                       reset_transfer_acknowledgement):
+                                                       reset_queue):
         """
         Tests if all commands in the drop-down menu are processed correctly.
 
         :param qapp: Fixture providing `Qt` application context.
         :param qtbot: Fixture for widget interaction.
-        :param reset_queue: Fixture to reset `queue` in `utils.py` after testing.
-        :param reset_transfer_acknowledgement: Fixture to reset `transfer_acknowledgement` in `utils.py` 
-        after testing.
+        :param reset_queue: Fixture to reset the state of `backend/command_queue.py` after testing.
         """
         
         widget = CommandPrompt()
@@ -152,7 +138,7 @@ class TestCommandPrompt:
 
         # Selecting each command and submitting it
         for i in range(dropdown.count()):
-            update_transfer_acknowledgement()
+            command_queue.transfer_acknowledgment = False
             dropdown.setCurrentIndex(i)
 
             # Checks if correct command was selected
@@ -162,21 +148,21 @@ class TestCommandPrompt:
             commands_submitted.append(dropdown.itemText(i).strip())
 
             # Checks if transfer is acknowledged before submission
-            assert utils.transfer_acknowledgment == False, \
+            assert command_queue.transfer_acknowledgment == False, \
                 "Transfer to queue should not have been acknowledged yet"
 
             qtbot.mouseClick(widget.submit_button, Qt.MouseButton.LeftButton)
             
             # Checks if submit was acknowledged
-            assert utils.transfer_acknowledgment == True, "Transfer to queue should have been acknowledged"
+            assert command_queue.transfer_acknowledgment == True, "Transfer to queue should have been acknowledged"
         
         # Checks if all the commands were added to queue
-        assert queue.qsize() == dropdown.count(), \
-            f"Expected {queue.qsize()} commands, got {dropdown.count()}"
+        assert command_queue.command_queue.qsize() == dropdown.count(), \
+            f"Expected {command_queue.command_queue.qsize()} commands, got {dropdown.count()}"
         
         # Checks if all commands were enqueued in the correct order
         for command in commands_submitted:
-            dequeued_command_code = queue.get()
+            dequeued_command_code = command_queue.get_from_queue()
 
             assert dequeued_command_code == valid_commands[command], \
                 f"Expected {dequeued_command_code}, got {valid_commands[command]}"
@@ -187,7 +173,6 @@ class TestCommandPrompt:
                                                       widget: CommandPrompt,
                                                       monkeypatch: pytest.MonkeyPatch,
                                                       reset_queue,
-                                                      reset_transfer_acknowledgement,
                                                       count: int):
         """
         Tests if `process_command()` processes invalid commands correctly.
@@ -195,9 +180,7 @@ class TestCommandPrompt:
         :param qapp: Fixture providing `Qt` application context.
         :param widget: Fixture providing an instance of `CommandPrompt`.
         :param monkeypatch: Fixture to patch `currentText()` of `widget.command_dropdown`.
-        :param reset_queue: Fixture to reset `queue` in `utils.py` after testing.
-        :param reset_transfer_acknowledgement: Fixture to reset `transfer_acknowledgement` in `utils.py` 
-        after testing.
+        :param reset_queue: Fixture to reset the state of `backend/command_queue.py` after testing.
         :param count: No. of invalid commands to test with.
         """
         
@@ -220,8 +203,8 @@ class TestCommandPrompt:
             if dummy_command not in valid_commands:
                 widget.process_command()
 
-                assert queue.empty(), "Command should not have been uploaded to queue"
-                assert utils.transfer_acknowledgment == False, "Transfer should not have been acknowledged"
+                assert command_queue.command_queue.empty(), "Command should not have been uploaded to queue"
+                assert command_queue.transfer_acknowledgment == False, "Transfer should not have been acknowledged"
                 assert widget.result_label.text() == "Invalid command.", \
                     f"Expected \"Invalid command.\" got \"{widget.result_label.text()}\""
             else:
@@ -233,7 +216,6 @@ class TestCommandPrompt:
                                                   widget: CommandPrompt,
                                                   monkeypatch: pytest.MonkeyPatch,
                                                   reset_queue,
-                                                  reset_transfer_acknowledgement,
                                                   count: int):
         """
         Tests if `process_command()` processes a mix of valid and invalid commands correctly.
@@ -241,9 +223,7 @@ class TestCommandPrompt:
         :param qapp: Fixture providing `Qt` application context.
         :param widget: Fixture providing an instance of `CommandPrompt`.
         :param monkeypatch: Fixture to patch `currentText()` of `widget.command_dropdown`.
-        :param reset_queue: Fixture to reset `queue` in `utils.py` after testing.
-        :param reset_transfer_acknowledgement: Fixture to reset `transfer_acknowledgement` in `utils.py` 
-        after testing.
+        :param reset_queue: Fixture to reset the state of `backend/command_queue.py` after testing.
         :param count: No. of commands to test with.
         """
         
@@ -279,14 +259,14 @@ class TestCommandPrompt:
                 continue
         
         # Checks if ONLY all the valid commands were inserted into queue
-        assert queue.qsize() == len(expected_commands_codes_queue), \
-            f"Expected {len(expected_commands_codes_queue)} commands, got {queue.qsize()}"
+        assert command_queue.command_queue.qsize() == len(expected_commands_codes_queue), \
+            f"Expected {len(expected_commands_codes_queue)} commands, got {command_queue.command_queue.qsize()}"
         
         # Checks if all the valid commands were inserted in the correct order
         for command in expected_commands_codes_queue:
-            assert not queue.empty(), "Queue empty. It should have more commands"
+            assert not command_queue.command_queue.empty(), "Queue empty. It should have more commands"
 
-            command_extracted = queue.get()
+            command_extracted = command_queue.get_from_queue()
 
             assert command == command_extracted, f"Expected {command}, got {command_extracted}"
 
@@ -295,14 +275,11 @@ class TestCommandPrompt:
 class TestUtils:
     def test_enqueue_dequeue(self,
                              reset_queue,
-                             reset_transfer_acknowledgement,
                              count: int):
         """
         Tests if `add_to_queue()` enqueues and `get_from_queue()` dequeues properly.
 
-        :param reset_queue: Fixture to reset `queue` in `utils.py` after test.
-        :param reset_transfer_acknowledgement: Fixture to reset `transfer_acknowledgement` in `utils.py` 
-        after test.
+        :param reset_queue: Fixture to reset the state of `backend/command_queue.py` after testing.
         :param count: No. of commands to test with.
         """
         
@@ -310,10 +287,10 @@ class TestUtils:
 
         # Enqueueing commands
         for command in sample_commands_codes:
-            add_to_queue(command)
+            command_queue.add_to_queue(command)
 
         # Checking if commands are dequeued in correct order
         for command in sample_commands_codes:
-            dequeued_command = get_from_queue()
+            dequeued_command = command_queue.get_from_queue()
 
             assert dequeued_command == command, f"Expected {command}, got {dequeued_command}"

--- a/ground_station/backend/command_queue.py
+++ b/ground_station/backend/command_queue.py
@@ -1,0 +1,28 @@
+from queue import Queue
+
+# Global shared command queue
+command_queue: Queue[str] = Queue()
+
+# Transfer acknowledgment variable
+# NOTE: only used in tests, set to True when an entry is added to the command_queue.
+transfer_acknowledgment = False
+
+
+# Function to add the converted bits to the Queue
+def add_to_queue(bits: str) -> None:
+    global transfer_acknowledgment
+    command_queue.put(bits)
+    transfer_acknowledgment = True  # Set transfer acknowledgment to True
+    print("Acknowledgment: Data moved to queue.")
+
+
+# Function to retrieve the next item from the queue
+def get_from_queue() -> str | None:
+    if not command_queue.empty():
+        return command_queue.get()
+    return None
+
+
+# Function to show acknowledgment message
+def show_acknowledgment() -> None:
+    print("Conversion complete. Data added to queue.")

--- a/ground_station/backend/command_queue_state.py
+++ b/ground_station/backend/command_queue_state.py
@@ -1,7 +1,0 @@
-from queue import Queue
-
-# Global shared command queue
-command_queue = Queue()
-
-# Global flag (optional)
-transfer_acknowledgment = False

--- a/ground_station/frontend/command_prompt.py
+++ b/ground_station/frontend/command_prompt.py
@@ -1,17 +1,6 @@
-# command_prompt.py
-
-#imports first
 from PyQt6.QtWidgets import QWidget, QVBoxLayout, QComboBox, QPushButton, QLabel
 from . import utils
-
-#     is_valid_command,
-#     get_binary_from_dict,
-#     add_to_queue,
-#     show_acknowledgment,
-#     transfer_acknowledgment
-# )
-
-
+from ground_station.backend import command_queue
 
 class CommandPrompt(QWidget):
     def __init__(self):
@@ -46,22 +35,18 @@ class CommandPrompt(QWidget):
 
     def process_command(self):
         # Get the selected command
-        # global transfer_acknowledgment   - not needed anymore
-
         command = self.command_dropdown.currentText().strip()
 
         if utils.is_valid_command(command):
             # Convert and enqueue
             bits = utils.get_binary_from_dict(command)
-            utils.add_to_queue(bits)
-            utils.show_acknowledgment()
-
-            utils.transfer_acknowledgment = True
+            command_queue.add_to_queue(bits)
+            command_queue.show_acknowledgment()
 
             self.result_label.setText("Command processed and moved to queue.")
         
         else:
             # reset flag for an invalid command
-            utils.transfer_acknowledgment = False
+            command_queue.transfer_acknowledgment = False
 
             self.result_label.setText("Invalid command.")

--- a/ground_station/frontend/utils.py
+++ b/ground_station/frontend/utils.py
@@ -1,9 +1,6 @@
 # Valid Commands Dictionary
 # Keys - Commands : Values - Binary
 
-
-from ..backend import command_queue_state
-
 valid_commands = {
     "ping": "0000",
     "nominal": "0001",
@@ -11,49 +8,30 @@ valid_commands = {
     "telemetry": "0011",
     "Camera-1-End": "0100",
     "Camera-2-End": "0110",
-    "Req Retransmission": "1000"
+    "Req Retransmission": "1000",
 }
+
 
 # Function to check if the command is valid
 def is_valid_command(command: str) -> bool:
     return command in valid_commands
 
+
 # Function to get the binary from the dictionary
 def get_binary_from_dict(command: str) -> str:
     return valid_commands.get(command, "")
 
-# Queue to hold the converted data
-# queue = [] , not using this anymore.
-queue = command_queue_state.command_queue
 
-# Transfer acknowledgment variable
-transfer_acknowledgment = False
-
-# Function to add the converted bits to the Queue
-def add_to_queue(bits: str) -> None:
-    global transfer_acknowledgment
-    queue.put(bits)
-    transfer_acknowledgment = True  # Set transfer acknowledgment to True
-    print("Acknowledgment: Data moved to queue.")
-
-# Function to retrieve the next item from the queue
-def get_from_queue() -> str | None:
-    if not queue.empty():
-        return queue.get()
-    return None
-
-# Function to show acknowledgment message
-def show_acknowledgment() -> None:
-    print("Conversion complete. Data added to queue.")
-
-# Example payload types 
+# Example payload types
 payload_type_1 = "nominal"
 payload_type_2 = "low power"
 payload_type_3 = "ping"
 
+
 # Merge the payloads for transfer (binary concatenation)
 def merge_payloads() -> str:
-    return ''.join(
-        get_binary_from_dict(p) for p in (payload_type_1, payload_type_2, payload_type_3)
+    return "".join(
+        get_binary_from_dict(p)
+        for p in (payload_type_1, payload_type_2, payload_type_3)
         if is_valid_command(p)
     )


### PR DESCRIPTION
Resolves #71 

* Removes a duplicate `transfer_acknowledgment` flag introduced in #63 
* Moves all `command_queue`-related features into their own file
* Updates tests to match