### PR TITLE
Reorder Dockerfiles to take advantage of layer caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,8 @@ env
 # python bytecode files
 __pycache__
 *.pyc
+
+# Git
+.git
+.gitignore
+.gitattributes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,15 @@
 # use official Python image with size around 200 MB
 FROM python:3.11-slim
 
-# set python env path
-ENV PYTHONPATH=/app
-
 # set working directory inside container
 WORKDIR /app
 
-# copy all files to container
-COPY . /app
+COPY requirements.txt ./
 
 # install dependencies with size around 1.2 GB
-RUN pip install --upgrade pip && \
-    pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
+# copy all files to container
+COPY . .
 
-# EXPOSE 5000
-CMD ["python", "./ground_station/frontend/main_window.py"]  # create bash script to initiate the application
-
-# convert current pipeline to multistage to reduce the image size
+CMD ["python", "-m", "ground_station.frontend.main_window"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -44,6 +44,9 @@ RUN pip install --no-cache-dir -r requirements.txt && \
 # copy all files to container
 COPY . .
 
+# set python env path
+ENV PYTHONPATH=/app
+
 RUN chmod +x ./entrypoint.sh
 # run the tests with virtual display
 CMD ["./entrypoint.sh"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -30,21 +30,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     xvfb \
     x11-utils \
     curl \
- && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# set python env path
-ENV PYTHONPATH=/app
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # set working directory inside container
 WORKDIR /app
 
-# copy all files to container
-COPY . /app
+COPY requirements.txt ./
 
 # install dependencies with size around 1.3 GB
-RUN pip install --upgrade pip && \
-    pip install -r requirements.txt && \
-    pip install pytest pytest-qt
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir pytest pytest-qt
+
+# copy all files to container
+COPY . .
 
 RUN chmod +x ./entrypoint.sh
 # run the tests with virtual display

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # UVR_SLIP-GS
 UVR SLIP ground station
+
+## Running the application
+
+### Install dependencies
+
+Create a virtual environment:
+```sh
+python -m venv venv
+```
+
+Install dependencies:
+```sh
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Run
+
+To launch the GUI:
+```sh
+python3 -m ground_station.frontend.main_window
+```
+
+To run tests:
+```sh
+pytest
+```


### PR DESCRIPTION
Adds a .dockerignore file and allows Docker to cache the `pip install` layer
